### PR TITLE
RFC: WIP: JSON endpoint for modifying the global read-only state

### DIFF
--- a/src/bzzz/core.clj
+++ b/src/bzzz/core.clj
@@ -94,7 +94,11 @@
                                               (.toString s)))]))
              "/favicon.ico" "" ;; XXX
 
-             ;; FIXME use post instead?
+             "/_state/temp_assoc_in"           (state/temp-assoc-in (:data input))
+             "/_state/temp_empty"              (state/temp-empty)
+             "/_state/ro_replace_with_temp"    (state/ro-replace-with-temp)
+             "/_state/ro_merge_with_temp"      (state/ro-merge-with-temp)
+             "/_state/ro_deep_merge_with_temp" (state/ro-deep-merge-with-temp)
              "/_state/ro_merge"      (state/ro-merge input)
              "/_state/ro_deep_merge" (state/ro-deep-merge input)
              "/_state/ro_rename_key" (state/ro-rename-key (:from_key input) (:to_key input))

--- a/src/bzzz/core.clj
+++ b/src/bzzz/core.clj
@@ -14,6 +14,7 @@
   (:require [bzzz.index-stat :as index-stat])
   (:require [bzzz.analyzer :as analyzer])
   (:require [bzzz.query :as query])
+  (:require [bzzz.state :as state])
   (:require [clojure.core.async :as async])
   (:require [clojure.tools.cli :refer [parse-opts]])
   (:require [clojure.data.json :as json])
@@ -92,6 +93,12 @@
                                    (into [] (for [^StackTraceElement s traces]
                                               (.toString s)))]))
              "/favicon.ico" "" ;; XXX
+
+             ;; FIXME use post instead?
+             "/_state/ro_merge"      (state/ro-merge (:data input))
+             "/_state/ro_deep_merge" (state/ro-deep-merge (:data input))
+             "/_state/ro_rename_key" (state/ro-rename-key (:from_key input) (:to_key input))
+
              (index-search/search input))
       :put (search-many (:hosts input) (dissoc input :hosts))
       :patch (discover/merge-discover-hosts (get input :discover-hosts {}))

--- a/src/bzzz/core.clj
+++ b/src/bzzz/core.clj
@@ -95,8 +95,8 @@
              "/favicon.ico" "" ;; XXX
 
              ;; FIXME use post instead?
-             "/_state/ro_merge"      (state/ro-merge (:data input))
-             "/_state/ro_deep_merge" (state/ro-deep-merge (:data input))
+             "/_state/ro_merge"      (state/ro-merge input)
+             "/_state/ro_deep_merge" (state/ro-deep-merge input)
              "/_state/ro_rename_key" (state/ro-rename-key (:from_key input) (:to_key input))
 
              (index-search/search input))

--- a/src/bzzz/state.clj
+++ b/src/bzzz/state.clj
@@ -3,11 +3,10 @@
   (use [clojure.set :only (rename-keys)])
   (:import (bzzz.java.query TermPayloadClojureScoreQuery)))
 
-;; FIXME Depending on the usage pattern, this can be terribly inefficient.
-;;       If this becomes a problem, we should consider a flow where we
-;;       write to the RW state and just merge into RO once the data pumping
-;;       is complete.
 ;; TODO Maybe add support for @hosts?
+;; FIXME Deep-merges don't seem very useful anymore. Drop 'em?
+
+(def temporary-state (atom {}))
 
 (defn ro-merge
   "Merge the given data map into the global read-only state.
@@ -53,3 +52,37 @@
   (let [ro-state (into {} TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO)]
     (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
       (rename-keys ro-state { (keyword from_key) (keyword to_key) }))))
+
+(defn temp-assoc-in
+  "Associates input data into the temporary map.
+
+  Example:
+  (temp-assoc-in [ [[:foo :bar] 1] [[:foo :baz] 2] ])
+  ;;=> { :foo { :bar 1, :baz 2 } }
+  "
+  [data]
+  (doseq [[k v] data] (swap! temporary-state assoc-in k v)))
+
+(defn temp-empty
+  "Erases the data saved in the temporary state."
+  []
+  (swap! temporary-state empty))
+
+(defn ro-replace-with-temp
+  "Replaces the global read-only state with the contents of the temporary state."
+  []
+  (TermPayloadClojureScoreQuery/replace_expr_global_state_ro @temporary-state))
+
+(defn ro-merge-with-temp
+  "Merges the temporary state with the global read-only one.
+
+  Refer to bzzz.state.ro-merge for details"
+  []
+  (ro-merge @temporary-state))
+
+(defn ro-deep-merge-with-temp
+  "Deep-merges the temporary state with the global read-only one.
+
+  Refer to bzzz.state.ro-deep-merge for details"
+  []
+  (ro-deep-merge @temporary-state))

--- a/src/bzzz/state.clj
+++ b/src/bzzz/state.clj
@@ -1,16 +1,12 @@
 (ns bzzz.state
   (use bzzz.util)
   (use [clojure.set :only (rename-keys)])
-  (:import (java.util HashMap Map))
   (:import (bzzz.java.query TermPayloadClojureScoreQuery)))
 
 ;; FIXME Depending on the usage pattern, this can be terribly inefficient.
 ;;       If this becomes a problem, we should consider a flow where we
 ;;       write to the RW state and just merge into RO once the data pumping
 ;;       is complete.
-;; FIXME All these conversions to java.util.HashMap seem really wasteful and
-;;       make it all kinda silly, especially because it doesn't convert the
-;;       values, so it probably beats the purpose. Get rid of it? Fix it?
 ;; TODO Maybe add support for @hosts?
 
 (defn ro-merge
@@ -25,8 +21,7 @@
   The behavior is exactly the same as clojure.core/merge"
   [data]
   (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
-    (java.util.HashMap. ^java.util.Map
-      (merge {} TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO data))))
+    (merge {} TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO data)))
 
 (defn ro-deep-merge
   "Deeply merge given data map into the global read-only state.
@@ -41,8 +36,7 @@
   Refer to bzzz.util/deep-merge for more details"
   [data]
   (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
-    (java.util.HashMap. ^java.util.Map
-      (deep-merge (into {} TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO) data))))
+    (deep-merge (into {} TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO) data)))
 
 (defn ro-rename-key
   "Rename a top-level key in the global read-only state.
@@ -58,5 +52,4 @@
   [from_key to_key]
   (let [ro-state (into {} TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO)]
     (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
-      (java.util.HashMap. ^java.util.Map
-        (rename-keys ro-state { (keyword from_key) (keyword to_key) })))))
+      (rename-keys ro-state { (keyword from_key) (keyword to_key) }))))

--- a/src/bzzz/state.clj
+++ b/src/bzzz/state.clj
@@ -35,7 +35,7 @@
   Refer to bzzz.util/deep-merge for more details"
   [data]
   (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
-    (deep-merge (into {} TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO) data)))
+    (deep-merge TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO data)))
 
 (defn ro-rename-key
   "Rename a top-level key in the global read-only state.
@@ -49,9 +49,9 @@
   (ro-deep-merge { :tmp-dataset { :bar 5 }})
   (ro-rename :tmp-dataset :dataset)"
   [from_key to_key]
-  (let [ro-state (into {} TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO)]
-    (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
-      (rename-keys ro-state { (keyword from_key) (keyword to_key) }))))
+  (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
+    (rename-keys TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO
+                 { (keyword from_key) (keyword to_key) })))
 
 (defn temp-assoc-in
   "Associates input data into the temporary map.

--- a/src/bzzz/state.clj
+++ b/src/bzzz/state.clj
@@ -1,0 +1,62 @@
+(ns bzzz.state
+  (use bzzz.util)
+  (use [clojure.set :only (rename-keys)])
+  (:import (java.util HashMap Map))
+  (:import (bzzz.java.query TermPayloadClojureScoreQuery)))
+
+;; FIXME Depending on the usage pattern, this can be terribly inefficient.
+;;       If this becomes a problem, we should consider a flow where we
+;;       write to the RW state and just merge into RO once the data pumping
+;;       is complete.
+;; FIXME All these conversions to java.util.HashMap seem really wasteful and
+;;       make it all kinda silly, especially because it doesn't convert the
+;;       values, so it probably beats the purpose. Get rid of it? Fix it?
+;; TODO Maybe add support for @hosts?
+
+(defn ro-merge
+  "Merge the given data map into the global read-only state.
+
+  This is useful for one-shot updates, where the whole state can
+  safely fit into a request.
+
+  Example:
+  (ro-merge { :small-table [...] })
+
+  The behavior is exactly the same as clojure.core/merge"
+  [data]
+  (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
+    (java.util.HashMap. ^java.util.Map
+      (merge {} TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO data))))
+
+(defn ro-deep-merge
+  "Deeply merge given data map into the global read-only state.
+
+  This is useful for incremental updates, where you can't (or shouldn't)
+  send the whole state in the same request.
+
+  Example:
+  (ro-deep-merge { :dataset { :foo 1 }})
+  (ro-deep-merge { :dataset { :bar 2 }})
+
+  Refer to bzzz.util/deep-merge for more details"
+  [data]
+  (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
+    (java.util.HashMap. ^java.util.Map
+      (deep-merge (into {} TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO) data))))
+
+(defn ro-rename-key
+  "Rename a top-level key in the global read-only state.
+
+  This can be used for scenarios where having an outdated state is
+  preferable over having a partially updated one. Typically coupled
+  with bzzz.state/ro-deep-merge.
+
+  Example:
+  (ro-deep-merge { :tmp-dataset { :foo 3 }})
+  (ro-deep-merge { :tmp-dataset { :bar 5 }})
+  (ro-rename :tmp-dataset :dataset)"
+  [from_key to_key]
+  (let [ro-state (into {} TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO)]
+    (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
+      (java.util.HashMap. ^java.util.Map
+        (rename-keys ro-state { from_key to_key })))))

--- a/src/bzzz/state.clj
+++ b/src/bzzz/state.clj
@@ -59,4 +59,4 @@
   (let [ro-state (into {} TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO)]
     (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
       (java.util.HashMap. ^java.util.Map
-        (rename-keys ro-state { from_key to_key })))))
+        (rename-keys ro-state { (keyword from_key) (keyword to_key) })))))

--- a/src/bzzz/util.clj
+++ b/src/bzzz/util.clj
@@ -210,3 +210,15 @@
 
 (defn cond-for-future-per-shard [input default n-shards]
   (and (read-boolean-setting input :future default) (> n-shards 1)))
+
+; Ref: https://github.com/puppetlabs/clj-kitchensink/commit/32a1a3a98ad08d521e58ccf88062eb7209992973
+(defn deep-merge
+  "Deeply merges maps so that nested maps are combined rather than replaced.
+
+  For example:
+  (deep-merge {:foo {:bar :baz}} {:foo {:fuzz :buzz}})
+  ;;=> {:foo {:bar :baz, :fuzz :buzz}}"
+  [& vs]
+  (if (every? map? vs)
+    (apply merge-with deep-merge vs)
+    (last vs)))

--- a/src/java/bzzz/java/query/TermPayloadClojureScoreQuery.java
+++ b/src/java/bzzz/java/query/TermPayloadClojureScoreQuery.java
@@ -10,6 +10,7 @@ import clojure.lang.Var;
 import clojure.lang.IFn;
 import clojure.lang.Compiler;
 import clojure.lang.Keyword;
+import clojure.lang.PersistentArrayMap;
 import java.io.StringReader;
 import java.lang.StringBuilder;
 import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap.Builder;
@@ -23,7 +24,7 @@ public class TermPayloadClojureScoreQuery extends Query {
     public static int GLOBAL_STATE_CAPACITY = 100000; // TODO: make this a parameter
 
     public static Map<Object,Object> EXPR_GLOBAL_STATE = new Builder<Object,Object>().maximumWeightedCapacity(GLOBAL_STATE_CAPACITY).build();
-    public static Map<Object,Object> EXPR_GLOBAL_STATE_RO = new HashMap<Object,Object>();
+    public static Map<Object,Object> EXPR_GLOBAL_STATE_RO = PersistentArrayMap.EMPTY;
     final public List<Term> terms;
     public String expr;
     public String[] field_cache_req;

--- a/test/bzzz/state_test.clj
+++ b/test/bzzz/state_test.clj
@@ -1,7 +1,6 @@
 (ns bzzz.state-test
   (:use clojure.test
         [bzzz.state :as state])
-  (:import (java.util HashMap Map))
   (:import (bzzz.java.query TermPayloadClojureScoreQuery)))
 
 (defn ro-get-in [k & [default]]
@@ -12,9 +11,10 @@
       (str "Global State: " TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO)))
 
 (deftest test-state
+
   (testing "cleanup the global RO state leaves no key behind"
     (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
-      (new java.util.HashMap))
+      (hash-map))
     (is (= TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO {})))
 
   (testing "merge overwrites keys with their values"

--- a/test/bzzz/state_test.clj
+++ b/test/bzzz/state_test.clj
@@ -1,0 +1,43 @@
+(ns bzzz.state-test
+  (:use clojure.test
+        [bzzz.state :as state])
+  (:import (java.util HashMap Map))
+  (:import (bzzz.java.query TermPayloadClojureScoreQuery)))
+
+(defn ro-get-in [k & [default]]
+  (get-in TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO k default))
+
+(defn ro-get-in-equals-to [k target]
+  (is (= (ro-get-in k) target)
+      (str "Global State: " TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO)))
+
+(deftest test-state
+  (testing "cleanup the global RO state leaves no key behind"
+    (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
+      (new java.util.HashMap))
+    (is (= TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO {})))
+
+  (testing "merge overwrites keys with their values"
+    (state/ro-merge { :foo 1, :bar 2 })
+    (is (= (ro-get-in [:foo]) 1))
+    (is (= (ro-get-in [:bar]) 2)))
+
+  (testing "deep-merge keeps nested keys untouched"
+    (state/ro-deep-merge { :foo { :bar 1 }})
+    (state/ro-deep-merge { :foo { :baz 2 }})
+    (is (= (ro-get-in [:foo :bar]) 1) (str "Wrong nested key " TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO))
+    (is (= (ro-get-in [:foo :baz]) 2) (str "Wrong nested key " TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO))
+
+    (testing "while always the value associated if the key exists"
+      (state/ro-deep-merge { :foo { :baz 3 }})
+      (is (= (ro-get-in [:foo :baz]) 3) (str "Wrong nested key " TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO))))
+
+  (testing "rename changes the key name"
+    (let [test-data {:foo 1, :bar 2, :baz 3}]
+      (state/ro-merge { :before-key test-data })
+      (is (= (ro-get-in [:before-key]) test-data))
+      (state/ro-rename-key :before-key :after-key)
+      (is (= (ro-get-in [:after-key]) test-data))
+
+      (testing "and makes sure the old key doesn't exist anymore"
+        (is (nil? (ro-get-in [:before-key])))))))

--- a/test/bzzz/state_test.clj
+++ b/test/bzzz/state_test.clj
@@ -6,9 +6,13 @@
 (defn ro-get-in [k & [default]]
   (get-in TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO k default))
 
-(defn ro-get-in-equals-to [k target]
+(defn ro-get-in-equals-to [k target & [msg]]
   (is (= (ro-get-in k) target)
-      (str "Global State: " TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO)))
+      (str (if msg (str msg "\n") "") "Global state: " TermPayloadClojureScoreQuery/EXPR_GLOBAL_STATE_RO)))
+
+(defn temp-get-in-equals-to [k target & [msg] ]
+  (is (= (get-in @state/temporary-state k) target)
+      (str (if msg (str msg "\n") "") "Temporary state: " @state/temporary-state)))
 
 (deftest test-state
 
@@ -44,4 +48,36 @@
 
       (testing "and lets me be lousy rename using a string instead of a keyword. sigh."
         (state/ro-rename-key "after-key" "before-key")
-        (ro-get-in-equals-to [:before-key] test-data)))))
+        (ro-get-in-equals-to [:before-key] test-data))))
+
+  (testing "temporary state"
+
+    (testing "assoc-in adds keys properly"
+      (state/temp-assoc-in [ [[:foo :bar] 42] [[:foo :baz] 24] ])
+      (temp-get-in-equals-to [:foo :bar] 42)
+      (temp-get-in-equals-to [:foo :baz] 24))
+
+    (testing "replace overwrites the global state"
+      ;; erase the global state
+      (TermPayloadClojureScoreQuery/replace_expr_global_state_ro (hash-map))
+      (state/ro-replace-with-temp)
+      (ro-get-in-equals-to [:foo :bar] 42)
+      (ro-get-in-equals-to [:foo :baz] 24))
+
+    (testing "merge does the right thing"
+      ;; preload the global state
+      (TermPayloadClojureScoreQuery/replace_expr_global_state_ro { :foo { :bar 12 :foobar 1024 } })
+      (state/ro-merge-with-temp)
+      (ro-get-in-equals-to [:foo :foobar] nil "Subkeys should disapear")
+      (ro-get-in-equals-to [:foo :bar] 42 "But collisions should be replaced"))
+
+    (testing "deep-merge also does the right thing"
+      ;; preload the global state
+      (TermPayloadClojureScoreQuery/replace_expr_global_state_ro { :foo { :bar 12 :foobar 1024 } })
+      (state/ro-deep-merge-with-temp)
+      (ro-get-in-equals-to [:foo :foobar] 1024 "Old keys should not disappear")
+      (ro-get-in-equals-to [:foo :bar] 42 "But collisions should be replaced"))
+
+    (testing "and empty actually erases it"
+      (state/temp-empty)
+      (is (= @state/temporary-state {})))))

--- a/test/bzzz/state_test.clj
+++ b/test/bzzz/state_test.clj
@@ -40,4 +40,8 @@
       (is (= (ro-get-in [:after-key]) test-data))
 
       (testing "and makes sure the old key doesn't exist anymore"
-        (is (nil? (ro-get-in [:before-key])))))))
+        (is (nil? (ro-get-in [:before-key]))))
+
+      (testing "and lets me be lousy rename using a string instead of a keyword. sigh."
+        (state/ro-rename-key "after-key" "before-key")
+        (ro-get-in-equals-to [:before-key] test-data)))))

--- a/test/bzzz/state_test.clj
+++ b/test/bzzz/state_test.clj
@@ -16,6 +16,9 @@
 
 (deftest test-state
 
+  (testing "rename in the initial state don't fail"
+    (state/ro-rename-key :a :b))
+
   (testing "cleanup the global RO state leaves no key behind"
     (TermPayloadClojureScoreQuery/replace_expr_global_state_ro
       (hash-map))


### PR DESCRIPTION
Oy,

This branch allows us to play with `EXPR_GLOBAL_STATE_RO` outside of the `search-many` context. There is plenty I'm not really happy with yet (expressed as `FIXME` comments in the files):
1. We replace the global state every single time. If we are pumping too much data, this is less than ideal. Still need to check if it's worth to use the read-write state as a temporary store
2. Clojure's hash-map to java.util.HashMap everywhere. It's rather silly. We should either completely remove it or do a proper conversion (including values).
3. Using `GET` because lazy :lollipop: 

Anyway, just getting the conversation started, I don't expect this to be merged as-is. Bash away! Also please bash my clojure-fu, I'm learning it as I write this :-)

Cheers
